### PR TITLE
feat: stream key management, dashboard overhaul, and create stream improvements

### DIFF
--- a/app/api/streams/[id]/streamkey/route.ts
+++ b/app/api/streams/[id]/streamkey/route.ts
@@ -1,0 +1,24 @@
+import { authOptions } from '@/lib/authOptions';
+import { getLiveStreamByBroadcastId } from '@/lib/youtube';
+import { getServerSession } from 'next-auth';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.access_token) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    const result = await getLiveStreamByBroadcastId(session.access_token, params.id);
+    if (!result) {
+      return NextResponse.json({ error: 'No stream key found for this broadcast' }, { status: 404 });
+    }
+    return NextResponse.json(result);
+  } catch (e) {
+    console.error('ERROR fetching stream key:', e);
+    return NextResponse.json(e, { status: 500 });
+  }
+}

--- a/app/api/streams/create/route.ts
+++ b/app/api/streams/create/route.ts
@@ -1,6 +1,6 @@
 import { authOptions } from '@/lib/authOptions';
 import { addToPlaylist } from '@/lib/playlists';
-import { createStream } from '@/lib/youtube';
+import { bindBroadcastToStream, createStream } from '@/lib/youtube';
 import { getServerSession } from 'next-auth';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -12,6 +12,7 @@ interface CreateStreamBody {
     autoStart?: string;
     autoStop?: string;
     playlistIds?: string;
+    streamKeyId?: string;
 }
 
 export async function POST(req: NextRequest) {
@@ -38,6 +39,13 @@ export async function POST(req: NextRequest) {
         });
 
         const videoId = result.data.id;
+
+        // Bind to stream key if requested
+        if (videoId && body.streamKeyId) {
+            try {
+                await bindBroadcastToStream(session.access_token, videoId, body.streamKeyId);
+            } catch { /* key binding is best-effort */ }
+        }
 
         // Add to selected playlists
         if (videoId && body.playlistIds) {

--- a/app/api/streams/edit/[id]/route.ts
+++ b/app/api/streams/edit/[id]/route.ts
@@ -1,7 +1,7 @@
 import { authOptions } from '@/lib/authOptions';
 import { addToPlaylist } from '@/lib/playlists';
 import { Stream, type StreamRequest, type YouTubeStreamData } from '@/lib/stream';
-import { editStream, getStreamById } from '@/lib/youtube';
+import { bindBroadcastToStream, editStream, getStreamById } from '@/lib/youtube';
 import { getServerSession } from 'next-auth';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -14,7 +14,7 @@ export async function POST(
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   try {
-    const body = (await req.json()) as StreamRequest & { playlistIds?: string };
+    const body = (await req.json()) as StreamRequest & { playlistIds?: string; streamKeyId?: string };
     const apiStream = await getStreamById(session.access_token, body.id);
     const ytStreamData = apiStream.data.items?.[0];
     if (!ytStreamData) {
@@ -22,6 +22,11 @@ export async function POST(
     }
     const streamForAPI = new Stream(body, ytStreamData as unknown as YouTubeStreamData);
     await editStream(session.access_token, streamForAPI);
+
+    // Bind to a different stream key if requested
+    if (body.streamKeyId) {
+      await bindBroadcastToStream(session.access_token, body.id, body.streamKeyId);
+    }
 
     // Add to selected playlists
     if (body.playlistIds) {

--- a/app/api/streams/keys/route.ts
+++ b/app/api/streams/keys/route.ts
@@ -1,0 +1,26 @@
+import { authOptions } from '@/lib/authOptions';
+import type { AvailableStreamKey } from '@/lib/types';
+import { getMyLiveStreams } from '@/lib/youtube';
+import { getServerSession } from 'next-auth';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.access_token) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    const items = await getMyLiveStreams(session.access_token);
+    const keys: AvailableStreamKey[] = items.map((s) => ({
+      id: s.id ?? '',
+      name: s.snippet?.title ?? '',
+      resolution: s.cdn?.resolution ?? undefined,
+      frameRate: s.cdn?.frameRate ?? undefined,
+      ingestionType: s.cdn?.ingestionType ?? undefined,
+    }));
+    return NextResponse.json(keys);
+  } catch (e) {
+    console.error('ERROR fetching stream keys:', e);
+    return NextResponse.json(e, { status: 500 });
+  }
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,30 +1,63 @@
-import DashboardActions from '@/components/DashboardActions';
+import DashboardClient from '@/components/DashboardClient';
 import { authOptions } from '@/lib/authOptions';
+import type { FormattedStream } from '@/lib/types';
+import { formatStreams } from '@/lib/utils';
+import { getLiveStreamsByIds, getStreams } from '@/lib/youtube';
 import { getServerSession } from 'next-auth';
-import Link from 'next/link';
 import { redirect } from 'next/navigation';
+
+type BroadcastItem = { id?: string; contentDetails?: { boundStreamId?: string } };
+type BroadcastsResponse = { data?: { items?: BroadcastItem[] } };
 
 export default async function DashboardPage() {
   const session = await getServerSession(authOptions);
   if (!session) redirect('/login');
 
+  let activeStreams: FormattedStream[] = [];
+  let completedStreams: FormattedStream[] = [];
+  let upcomingCount = 0;
+
+  try {
+    const [active, completed, upcoming] = await Promise.all([
+      getStreams(session.access_token!, 'active'),
+      getStreams(session.access_token!, 'completed'),
+      getStreams(session.access_token!, 'upcoming'),
+    ]);
+
+    const allItems = [
+      ...((active as BroadcastsResponse).data?.items ?? []),
+      ...((completed as BroadcastsResponse).data?.items ?? []),
+    ];
+    const boundStreamIds = Array.from(
+      new Set(
+        allItems
+          .map((i) => i.contentDetails?.boundStreamId)
+          .filter((id): id is string => !!id),
+      ),
+    );
+    const liveStreamItems =
+      boundStreamIds.length > 0
+        ? await getLiveStreamsByIds(session.access_token!, boundStreamIds)
+        : [];
+
+    type LiveStreamItem = { id?: string; snippet?: { title?: string } };
+    const streamKeyNameMap = new Map(
+      (liveStreamItems as LiveStreamItem[]).map((s) => [s.id ?? '', s.snippet?.title ?? '']),
+    );
+
+    activeStreams = formatStreams(active, streamKeyNameMap);
+    completedStreams = formatStreams(completed, streamKeyNameMap);
+    upcomingCount = ((upcoming as BroadcastsResponse).data?.items ?? []).length;
+  } catch {
+    // degrade gracefully — dashboard still renders with empty data
+  }
+
   return (
-    <section className="py-24 text-center container mx-auto px-4">
-      <div className="max-w-lg mx-auto">
-        <h1 className="text-4xl font-light mb-4">Dashboard</h1>
-        <p className="text-gray-500 dark:text-gray-400 text-lg mb-8">
-          This is your livestream control dashboard. More controls can be found below.
-        </p>
-        <div className="flex justify-center gap-4 flex-wrap">
-          <Link
-            href="/streams"
-            className="bg-blue-600 text-white px-6 py-3 rounded-md font-medium hover:bg-blue-700 transition-colors"
-          >
-            Upcoming Streams
-          </Link>
-          <DashboardActions />
-        </div>
-      </div>
-    </section>
+    <DashboardClient
+      activeStreams={activeStreams}
+      completedStreams={completedStreams}
+      upcomingCount={upcomingCount}
+    />
   );
 }
+

--- a/app/streams/page.tsx
+++ b/app/streams/page.tsx
@@ -3,7 +3,7 @@ import { authOptions } from '@/lib/authOptions';
 import { streamStatus } from '@/lib/constants';
 import type { StreamsData, StreamsPageError } from '@/lib/types';
 import { formatStreams, parallelAsync } from '@/lib/utils';
-import { getStreams } from '@/lib/youtube';
+import { getLiveStreamsByIds, getStreams } from '@/lib/youtube';
 import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 
@@ -22,10 +22,26 @@ export default async function StreamsPage() {
       active: getStreams(session.access_token!, streamStatus.ACTIVE, 1),
       completed: getStreams(session.access_token!, streamStatus.COMPLETED, 50),
     });
-    const formattedCompleted = formatStreams(completed);
+
+    // Collect all bound stream IDs and batch-fetch their names in one call
+    type BroadcastItem = { contentDetails?: { boundStreamId?: string } };
+    const allItems = [
+      ...((active as { data?: { items?: BroadcastItem[] } }).data?.items ?? []),
+      ...((upcoming as { data?: { items?: BroadcastItem[] } }).data?.items ?? []),
+      ...((completed as { data?: { items?: BroadcastItem[] } }).data?.items ?? []),
+    ];
+    const boundStreamIds = Array.from(
+      new Set(
+        allItems.map((i) => i.contentDetails?.boundStreamId).filter((id): id is string => !!id),
+      ),
+    );
+    const liveStreamItems = await getLiveStreamsByIds(session.access_token!, boundStreamIds);
+    const streamKeyNameMap = new Map(liveStreamItems.map((s) => [s.id!, s.snippet?.title ?? '']));
+
+    const formattedCompleted = formatStreams(completed, streamKeyNameMap);
     streamsData = {
-      active: formatStreams(active),
-      upcoming: formatStreams(upcoming),
+      active: formatStreams(active, streamKeyNameMap),
+      upcoming: formatStreams(upcoming, streamKeyNameMap),
       completed: formattedCompleted,
       last: formattedCompleted.slice(0, 1),
     };

--- a/components/DashboardClient.tsx
+++ b/components/DashboardClient.tsx
@@ -1,0 +1,254 @@
+'use client';
+import type { FormattedStream } from '@/lib/types';
+import { toLocalDatetime } from '@/lib/utils';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import CreateStreamModal from './modals/CreateStreamModal';
+import EditStreamModal from './modals/EditStreamModal';
+import StopStreamModal from './modals/StopStreamModal';
+
+type Timeframe = 'day' | '7d' | '30d';
+
+const TF_LABELS: Record<Timeframe, string> = { day: 'Today', '7d': '7 Days', '30d': '30 Days' };
+
+function getTimeframeCutoff(tf: Timeframe): Date {
+  const now = new Date();
+  if (tf === 'day') return new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  if (tf === '7d') return new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  return new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+}
+
+interface Props {
+  activeStreams: FormattedStream[];
+  completedStreams: FormattedStream[];
+  upcomingCount: number;
+}
+
+export default function DashboardClient({ activeStreams, completedStreams, upcomingCount }: Props) {
+  const router = useRouter();
+  const [timeframe, setTimeframe] = useState<Timeframe>('7d');
+  const [stoppingStream, setStoppingStream] = useState<FormattedStream | null>(null);
+  const [editingStream, setEditingStream] = useState<FormattedStream | null>(null);
+  const [stopLoading, setStopLoading] = useState(false);
+  const [editLoading, setEditLoading] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const [createLoading, setCreateLoading] = useState(false);
+
+  const activeStream = activeStreams[0] ?? null;
+
+  const streamsInPeriod = completedStreams.filter((s) => {
+    const dateStr = s.actualStartTime ?? s.startTime;
+    return dateStr && new Date(dateStr) >= getTimeframeCutoff(timeframe);
+  });
+
+  const handleStop = async () => {
+    if (!stoppingStream) return;
+    setStopLoading(true);
+    try {
+      const res = await fetch(`/api/streams/stop/${stoppingStream.id}`, { method: 'POST' });
+      if (!res.ok) throw await res.json();
+      toast.success('Stream stopped');
+      setStoppingStream(null);
+      router.refresh();
+    } catch {
+      toast.error('Failed to stop stream');
+      setStoppingStream(null);
+    } finally {
+      setStopLoading(false);
+    }
+  };
+
+  const handleEdit = async (formData: Record<string, string>) => {
+    setEditLoading(true);
+    try {
+      const res = await fetch(`/api/streams/edit/${formData.id}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData),
+      });
+      if (!res.ok) throw await res.json();
+      toast.success('Stream updated');
+      setEditingStream(null);
+      router.refresh();
+    } catch {
+      toast.error('Failed to update stream');
+    } finally {
+      setEditLoading(false);
+    }
+  };
+
+  const handleCreate = async (formData: Record<string, string>) => {
+    setCreateLoading(true);
+    try {
+      const res = await fetch('/api/streams/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData),
+      });
+      if (!res.ok) throw await res.json();
+      toast.success('Stream created');
+      setIsCreating(false);
+      router.push('/streams');
+    } catch {
+      toast.error('Failed to create stream');
+    } finally {
+      setCreateLoading(false);
+    }
+  };
+
+  return (
+    <section className="py-10 container mx-auto px-4 max-w-3xl">
+      <h1 className="text-4xl font-light mb-2 text-center">Dashboard</h1>
+      <p className="text-gray-500 dark:text-gray-400 text-center mb-8">
+        Your livestream control centre.
+      </p>
+
+      {/* Primary actions — always prominent */}
+      <div className="flex justify-center gap-4 flex-wrap mb-8">
+        <Link
+          href="/streams"
+          className="bg-blue-600 text-white px-6 py-3 rounded-md font-medium hover:bg-blue-700 transition-colors"
+        >
+          Upcoming Streams
+        </Link>
+        <button
+          onClick={() => setIsCreating(true)}
+          className="bg-green-600 text-white px-6 py-3 rounded-md font-medium hover:bg-green-700 transition-colors"
+        >
+          Create Stream
+        </button>
+      </div>
+
+      {/* Active stream card */}
+      {activeStream && (
+        <div className="mb-6 rounded-xl border-2 border-red-500 dark:border-red-600 bg-white dark:bg-gray-800 shadow-sm p-4">
+          <div className="flex items-start justify-between gap-4 flex-wrap">
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 mb-1 flex-wrap">
+                <span className="inline-flex items-center gap-1.5 bg-red-600 text-white text-xs font-bold px-2 py-0.5 rounded animate-pulse">
+                  ● LIVE
+                </span>
+                <h2 className="font-semibold text-gray-900 dark:text-gray-100 truncate">
+                  {activeStream.title}
+                </h2>
+              </div>
+              {activeStream.streamKeyName && (
+                <p className="flex items-center gap-1 text-xs text-purple-600 dark:text-purple-400 font-mono mb-1">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3 h-3 shrink-0">
+                    <path fillRule="evenodd" d="M8 7a5 5 0 113.61 4.804l-1.903 1.903A1 1 0 019 14H8v1a1 1 0 01-1 1H6v1a1 1 0 01-1 1H3a1 1 0 01-1-1v-2a1 1 0 01.293-.707L8.196 8.39A5.002 5.002 0 018 7zm5-3a.75.75 0 000 1.5A1.5 1.5 0 0114.5 7 .75.75 0 0016 7a3 3 0 00-3-3z" clipRule="evenodd" />
+                  </svg>
+                  {activeStream.streamKeyName}
+                </p>
+              )}
+              {activeStream.actualStartTime && (
+                <p className="text-xs text-gray-400 dark:text-gray-500">
+                  Live since {toLocalDatetime(activeStream.actualStartTime)}
+                </p>
+              )}
+            </div>
+            <div className="flex items-center gap-2 flex-wrap">
+              <button
+                onClick={() => setStoppingStream(activeStream)}
+                className="inline-flex items-center gap-1 bg-red-600 text-white px-3 py-1.5 rounded text-sm font-medium hover:bg-red-700 transition-colors"
+              >
+                Stop
+              </button>
+              <button
+                onClick={() => setEditingStream(activeStream)}
+                className="inline-flex items-center gap-1 px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded text-sm hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+              >
+                Edit
+              </button>
+              <a
+                href={activeStream.controlRoomLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded text-sm hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+              >
+                Control Room ↗
+              </a>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Stream history metrics */}
+      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5">
+        <div className="flex items-center justify-between mb-5 flex-wrap gap-3">
+          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide">
+            Stream History
+          </h2>
+          <div className="flex items-center gap-1 rounded-lg border border-gray-200 dark:border-gray-700 p-0.5">
+            {(Object.keys(TF_LABELS) as Timeframe[]).map((tf) => (
+              <button
+                key={tf}
+                onClick={() => setTimeframe(tf)}
+                className={`px-3 py-1 text-xs rounded-md transition-colors font-medium ${
+                  timeframe === tf
+                    ? 'bg-blue-600 text-white'
+                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+                }`}
+              >
+                {TF_LABELS[tf]}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="grid grid-cols-3 gap-4">
+          <div className="rounded-lg bg-gray-50 dark:bg-gray-900/50 p-4 text-center">
+            <p className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+              {streamsInPeriod.length}
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Completed in {TF_LABELS[timeframe].toLowerCase()}
+            </p>
+          </div>
+          <div className="rounded-lg bg-gray-50 dark:bg-gray-900/50 p-4 text-center">
+            <p className="text-3xl font-bold text-gray-900 dark:text-gray-100">{upcomingCount}</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Upcoming scheduled</p>
+          </div>
+          {activeStream ? (
+            <div className="rounded-lg bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-900 p-4 text-center">
+              <p className="text-3xl font-bold text-red-600 dark:text-red-400">1</p>
+              <p className="text-xs text-red-500 dark:text-red-400 mt-1">Currently live</p>
+            </div>
+          ) : (
+            <div className="rounded-lg bg-gray-50 dark:bg-gray-900/50 p-4 text-center">
+              <p className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+                {completedStreams.length}
+              </p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">All completed</p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Modals */}
+      {stoppingStream && (
+        <StopStreamModal
+          stream={stoppingStream}
+          loading={stopLoading}
+          onConfirm={handleStop}
+          onClose={() => setStoppingStream(null)}
+        />
+      )}
+      {editingStream && (
+        <EditStreamModal
+          stream={editingStream}
+          loading={editLoading}
+          onSubmit={handleEdit}
+          onClose={() => setEditingStream(null)}
+        />
+      )}
+      {isCreating && (
+        <CreateStreamModal
+          loading={createLoading}
+          onSubmit={handleCreate}
+          onClose={() => setIsCreating(false)}
+        />
+      )}
+    </section>
+  );
+}

--- a/components/StreamCard.tsx
+++ b/components/StreamCard.tsx
@@ -109,7 +109,22 @@ export default function StreamCard({ stream, onEdit, onDelete, onCopy, selected,
             </span>
           </label>
         </div>
-        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4 line-clamp-3 flex-1">{stream.description}</p>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-2 line-clamp-3">{stream.description}</p>
+        {stream.streamKeyName ? (
+          <p className="flex items-center gap-1 text-xs text-purple-600 dark:text-purple-400 mb-3 font-mono">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3 h-3 shrink-0">
+              <path fillRule="evenodd" d="M8 7a5 5 0 113.61 4.804l-1.903 1.903A1 1 0 019 14H8v1a1 1 0 01-1 1H6v1a1 1 0 01-1 1H3a1 1 0 01-1-1v-2a1 1 0 01.293-.707L8.196 8.39A5.002 5.002 0 018 7zm5-3a.75.75 0 000 1.5A1.5 1.5 0 0114.5 7 .75.75 0 0016 7a3 3 0 00-3-3z" clipRule="evenodd" />
+            </svg>
+            {stream.streamKeyName}
+          </p>
+        ) : (
+          <p className="flex items-center gap-1 text-xs text-gray-400 dark:text-gray-600 mb-3 italic">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3 h-3 shrink-0">
+              <path fillRule="evenodd" d="M8 7a5 5 0 113.61 4.804l-1.903 1.903A1 1 0 019 14H8v1a1 1 0 01-1 1H6v1a1 1 0 01-1 1H3a1 1 0 01-1-1v-2a1 1 0 01.293-.707L8.196 8.39A5.002 5.002 0 018 7zm5-3a.75.75 0 000 1.5A1.5 1.5 0 0114.5 7 .75.75 0 0016 7a3 3 0 00-3-3z" clipRule="evenodd" />
+            </svg>
+            No key bound
+          </p>
+        )}
         <div className="flex items-center gap-2 flex-wrap">
           <a
             href={stream.videoLink}

--- a/components/StreamFeatured.tsx
+++ b/components/StreamFeatured.tsx
@@ -53,7 +53,17 @@ export default function StreamFeatured({ active, last, onStop, onEdit }: StreamF
               <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">
                 <strong>Live Since:</strong> {toLocalDatetime(stream.actualStartTime)}
               </p>
-              <p className="text-xs text-gray-400 dark:text-gray-500 mb-4 font-mono">{stream.id}</p>
+              <p className="text-xs text-gray-400 dark:text-gray-500 mb-1 font-mono">{stream.id}</p>
+              {stream.streamKeyName ? (
+                <p className="flex items-center gap-1 text-xs text-purple-600 dark:text-purple-400 mb-4 font-mono">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3 h-3 shrink-0">
+                    <path fillRule="evenodd" d="M8 7a5 5 0 113.61 4.804l-1.903 1.903A1 1 0 019 14H8v1a1 1 0 01-1 1H6v1a1 1 0 01-1 1H3a1 1 0 01-1-1v-2a1 1 0 01.293-.707L8.196 8.39A5.002 5.002 0 018 7zm5-3a.75.75 0 000 1.5A1.5 1.5 0 0114.5 7 .75.75 0 0016 7a3 3 0 00-3-3z" clipRule="evenodd" />
+                  </svg>
+                  {stream.streamKeyName}
+                </p>
+              ) : (
+                <p className="text-xs text-gray-400 dark:text-gray-600 mb-4 italic">No key bound</p>
+              )}
               <div className="flex flex-wrap gap-2">
                 <button
                   onClick={() => onStop(stream)}

--- a/components/StreamTableRow.tsx
+++ b/components/StreamTableRow.tsx
@@ -47,6 +47,18 @@ export default function StreamTableRow({ stream, onEdit, onDelete, onCopy, selec
                     {stream.privacyStatus}
                 </span>
             </td>
+            <td className="py-3 px-4">
+                {stream.streamKeyName ? (
+                    <span className="inline-flex items-center gap-1 text-xs font-mono text-purple-700 dark:text-purple-400">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3 h-3 shrink-0">
+                            <path fillRule="evenodd" d="M8 7a5 5 0 113.61 4.804l-1.903 1.903A1 1 0 019 14H8v1a1 1 0 01-1 1H6v1a1 1 0 01-1 1H3a1 1 0 01-1-1v-2a1 1 0 01.293-.707L8.196 8.39A5.002 5.002 0 018 7zm5-3a.75.75 0 000 1.5A1.5 1.5 0 0114.5 7 .75.75 0 0016 7a3 3 0 00-3-3z" clipRule="evenodd" />
+                        </svg>
+                        {stream.streamKeyName}
+                    </span>
+                ) : (
+                    <span className="text-xs text-gray-400 dark:text-gray-600 italic">—</span>
+                )}
+            </td>
             <td className="py-3 px-4 text-center">
                 <div className="inline-flex items-center justify-center gap-1.5 mx-auto">
                     <input

--- a/components/StreamsClient.tsx
+++ b/components/StreamsClient.tsx
@@ -14,6 +14,7 @@ import EditStreamModal from './modals/EditStreamModal';
 import Modal from './modals/Modal';
 import StopStreamModal from './modals/StopStreamModal';
 
+
 type ViewMode = 'grid' | 'table';
 type SortKey = 'title' | 'startTime' | 'privacyStatus' | 'enableAutoStart' | 'enableAutoStop';
 type SortDir = 'asc' | 'desc';
@@ -169,6 +170,7 @@ export default function StreamsClient({ streams, error }: StreamsClientProps) {
     const [deletingStream, setDeletingStream] = useState<FormattedStream | null>(null);
     const [createStreamData, setCreateStreamData] = useState<Partial<FormattedStream> | null>(null);
     const [streamsState, setStreamsState] = useState<StreamsData | null>(streams);
+
 
     const [upcomingView, setUpcomingView] = useState<ViewMode>('grid');
     const [upcomingSortKey, setUpcomingSortKey] = useState<SortKey>('startTime');
@@ -518,6 +520,13 @@ export default function StreamsClient({ streams, error }: StreamsClientProps) {
                                                 {streamsState.upcoming.length}
                                             </span>
                                         </h1>
+                                        <div className="flex items-center gap-2">
+                                        <button
+                                            onClick={() => setCreateStreamData({})}
+                                            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg bg-green-600 text-white hover:bg-green-700 transition-colors font-medium"
+                                        >
+                                            + Create Stream
+                                        </button>
                                         {uiMounted ? (
                                             <div className="flex items-center gap-1 border border-gray-200 dark:border-gray-700 rounded-md p-0.5">
                                                 <button
@@ -547,6 +556,7 @@ export default function StreamsClient({ streams, error }: StreamsClientProps) {
                                                 <div className="w-7 h-7 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
                                             </div>
                                         )}
+                                        </div>
                                     </div>
                                     <p className="text-xs text-gray-400 dark:text-gray-500 mb-4">10 items per page</p>
 
@@ -615,8 +625,7 @@ export default function StreamsClient({ streams, error }: StreamsClientProps) {
                                                                     <span className="ml-1 text-blue-500">{upcomingSortDir === 'asc' ? '↑' : '↓'}</span>
                                                                 )}
                                                             </th>
-                                                        ))}
-                                                        <th className="py-2.5 px-4 text-right">Actions</th>
+                                                        ))}                                                        <th className="py-2.5 px-4 text-left">Stream Key</th>                                                        <th className="py-2.5 px-4 text-right">Actions</th>
                                                     </tr>
                                                 </thead>
                                                 <tbody className="divide-y divide-gray-100 dark:divide-gray-700 bg-white dark:bg-gray-900">
@@ -734,6 +743,7 @@ export default function StreamsClient({ streams, error }: StreamsClientProps) {
                                                                 )}
                                                             </th>
                                                         ))}
+                                                        <th className="py-2.5 px-4 text-left">Stream Key</th>
                                                         <th className="py-2.5 px-4 text-right">Actions</th>
                                                     </tr>
                                                 </thead>

--- a/components/modals/CreateStreamModal.tsx
+++ b/components/modals/CreateStreamModal.tsx
@@ -1,7 +1,7 @@
 'use client';
-import type { FormattedStream } from '@/lib/types';
+import type { AvailableStreamKey, FormattedStream } from '@/lib/types';
 import { toDatetimeLocalValue } from '@/lib/utils';
-import { useState, type FormEvent } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 import PlaylistMultiSelect from '../PlaylistMultiSelect';
 import Modal from './Modal';
 
@@ -28,6 +28,20 @@ export default function CreateStreamModal({
     const [autoStart, setAutoStart] = useState(initialData?.enableAutoStart ?? true);
     const [autoStop, setAutoStop] = useState(initialData?.enableAutoStop ?? true);
     const [playlistIds, setPlaylistIds] = useState<string[]>([]);
+    const [availableKeys, setAvailableKeys] = useState<AvailableStreamKey[]>([]);
+    const [keysLoading, setKeysLoading] = useState(false);
+    const [selectedKeyId, setSelectedKeyId] = useState('');
+
+    useEffect(() => {
+        setKeysLoading(true);
+        fetch('/api/streams/keys')
+            .then(async (res) => {
+                if (!res.ok) return;
+                setAvailableKeys((await res.json()) as AvailableStreamKey[]);
+            })
+            .catch(() => {})
+            .finally(() => setKeysLoading(false));
+    }, []);
 
     const isCopy = !!initialData?.id;
 
@@ -44,6 +58,7 @@ export default function CreateStreamModal({
         if (playlistIds.length > 0) {
             obj.playlistIds = JSON.stringify(playlistIds);
         }
+        if (selectedKeyId) obj.streamKeyId = selectedKeyId;
         onSubmit(obj);
     };
 
@@ -136,6 +151,30 @@ export default function CreateStreamModal({
                         <option value="unlisted">Unlisted</option>
                         <option value="private">Private</option>
                     </select>
+                </div>
+
+                <div>
+                    <label className={labelClass} htmlFor="create-stream-key">
+                        Stream Key{' '}
+                        <span className="text-gray-400 dark:text-gray-500 text-xs font-normal">(optional)</span>
+                    </label>
+                    {keysLoading ? (
+                        <div className="h-9 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />
+                    ) : (
+                        <select
+                            id="create-stream-key"
+                            value={selectedKeyId}
+                            onChange={(e) => setSelectedKeyId(e.target.value)}
+                            className={inputClass}
+                        >
+                            <option value="">— select a stream key —</option>
+                            {availableKeys.map((k) => (
+                                <option key={k.id} value={k.id}>
+                                    {k.name}{k.resolution ? ` · ${k.resolution}` : ''}
+                                </option>
+                            ))}
+                        </select>
+                    )}
                 </div>
 
                 <div className="flex gap-6">

--- a/components/modals/EditStreamModal.tsx
+++ b/components/modals/EditStreamModal.tsx
@@ -1,7 +1,7 @@
 'use client';
-import type { FormattedStream } from '@/lib/types';
+import type { AvailableStreamKey, FormattedStream, StreamKeyInfo } from '@/lib/types';
 import { toDatetimeLocalValue, toLocalDatetime } from '@/lib/utils';
-import { useState, type FormEvent } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 import PlaylistMultiSelect from '../PlaylistMultiSelect';
 import Modal from './Modal';
 
@@ -10,6 +10,82 @@ interface EditStreamModalProps {
   loading: boolean;
   onSubmit: (data: Record<string, string>) => void;
   onClose: () => void;
+}
+
+function CopyButton({ value, label }: { value: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+    } catch {
+      const el = document.createElement('textarea');
+      el.value = value;
+      el.style.position = 'fixed';
+      el.style.left = '-9999px';
+      document.body.appendChild(el);
+      el.focus();
+      el.select();
+      document.execCommand('copy');
+      document.body.removeChild(el);
+    }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  };
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      title={`Copy ${label}`}
+      className="shrink-0 inline-flex items-center gap-1 text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+    >
+      {copied ? (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3.5 h-3.5 text-green-500">
+          <path fillRule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clipRule="evenodd" />
+        </svg>
+      ) : (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3.5 h-3.5">
+          <path d="M7 3.5A1.5 1.5 0 018.5 2h3.879a1.5 1.5 0 011.06.44l3.122 3.12A1.5 1.5 0 0117 6.622V12.5a1.5 1.5 0 01-1.5 1.5h-1v-3.379a3 3 0 00-.879-2.121L10.5 5.379A3 3 0 008.379 4.5H7v-1z" />
+          <path d="M4.5 6A1.5 1.5 0 003 7.5v9A1.5 1.5 0 004.5 18h7a1.5 1.5 0 001.5-1.5v-5.879a1.5 1.5 0 00-.44-1.06L9.44 6.439A1.5 1.5 0 008.378 6H4.5z" />
+        </svg>
+      )}
+      {copied ? 'Copied!' : 'Copy'}
+    </button>
+  );
+}
+
+function SecretRow({ label, value }: { label: string; value: string }) {
+  const [revealed, setRevealed] = useState(false);
+  const display = !revealed ? '•'.repeat(Math.min(value.length, 32)) : value;
+  return (
+    <div className="space-y-1">
+      <span className="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">{label}</span>
+      <div className="flex items-center gap-2">
+        <code className="flex-1 block text-xs bg-gray-100 dark:bg-gray-900 rounded px-2 py-1.5 font-mono break-all select-all">
+          {display}
+        </code>
+        <button
+          type="button"
+          onClick={() => setRevealed((r) => !r)}
+          title={revealed ? 'Hide' : 'Reveal'}
+          className="shrink-0 inline-flex items-center gap-1 text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+        >
+          {revealed ? (
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3.5 h-3.5">
+              <path fillRule="evenodd" d="M3.28 2.22a.75.75 0 00-1.06 1.06l14.5 14.5a.75.75 0 101.06-1.06l-1.745-1.745a10.029 10.029 0 003.3-4.38 1.651 1.651 0 000-1.185A10.004 10.004 0 009.999 3a9.956 9.956 0 00-4.744 1.194L3.28 2.22zM7.752 6.69l1.092 1.092a2.5 2.5 0 013.374 3.373l1.091 1.092a4 4 0 00-5.557-5.557z" clipRule="evenodd" />
+              <path d="M10.748 13.93l2.523 2.523a9.987 9.987 0 01-3.27.547c-4.258 0-7.894-2.66-9.337-6.41a1.651 1.651 0 010-1.186A10.007 10.007 0 012.839 6.02L6.07 9.252a4 4 0 004.678 4.678z" />
+            </svg>
+          ) : (
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3.5 h-3.5">
+              <path d="M10 12.5a2.5 2.5 0 100-5 2.5 2.5 0 000 5z" />
+              <path fillRule="evenodd" d="M.664 10.59a1.651 1.651 0 010-1.186A10.004 10.004 0 0110 3c4.257 0 7.893 2.66 9.336 6.41.147.381.146.804 0 1.186A10.004 10.004 0 0110 17c-4.257 0-7.893-2.66-9.336-6.41z" clipRule="evenodd" />
+            </svg>
+          )}
+          {revealed ? 'Hide' : 'Show'}
+        </button>
+        <CopyButton value={value} label={label} />
+      </div>
+    </div>
+  );
 }
 
 export default function EditStreamModal({
@@ -21,19 +97,56 @@ export default function EditStreamModal({
   const [autoStart, setAutoStart] = useState(stream.enableAutoStart);
   const [autoStop, setAutoStop] = useState(stream.enableAutoStop);
   const [playlistIds, setPlaylistIds] = useState<string[]>([]);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  // Stream key state
+  const [availableKeys, setAvailableKeys] = useState<AvailableStreamKey[]>([]);
+  const [keysLoading, setKeysLoading] = useState(false);
+  const [keysError, setKeysError] = useState<string | null>(null);
+  const [selectedKeyId, setSelectedKeyId] = useState<string>(stream.boundStreamId ?? '');
+  const [keyInfo, setKeyInfo] = useState<StreamKeyInfo | null>(null);
+  const [keyInfoLoading, setKeyInfoLoading] = useState(false);
+
+  // Fetch available keys when advanced section opens
+  useEffect(() => {
+    if (!showAdvanced || availableKeys.length > 0) return;
+    setKeysLoading(true);
+    setKeysError(null);
+    fetch('/api/streams/keys')
+      .then(async (res) => {
+        const data = await res.json() as AvailableStreamKey[] | { error: string };
+        if (!res.ok) throw new Error((data as { error: string }).error ?? 'Failed to load stream keys');
+        setAvailableKeys(data as AvailableStreamKey[]);
+      })
+      .catch((e: Error) => setKeysError(e.message))
+      .finally(() => setKeysLoading(false));
+  }, [showAdvanced, availableKeys.length]);
+
+  // Fetch credential details for the currently-selected key when advanced is open
+  useEffect(() => {
+    if (!showAdvanced || !selectedKeyId) { setKeyInfo(null); return; }
+    setKeyInfoLoading(true);
+    fetch(`/api/streams/${stream.id}/streamkey`)
+      .then(async (res) => {
+        if (!res.ok) { setKeyInfo(null); return; }
+        setKeyInfo(await res.json() as StreamKeyInfo);
+      })
+      .catch(() => setKeyInfo(null))
+      .finally(() => setKeyInfoLoading(false));
+  }, [showAdvanced, selectedKeyId, stream.id]);
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const form = e.currentTarget;
     const formData = new FormData(form);
     const obj: Record<string, string> = {};
-    formData.forEach((val, key) => {
-      obj[key] = val.toString();
-    });
+    formData.forEach((val, key) => { obj[key] = val.toString(); });
     obj.autoStart = String(autoStart);
     obj.autoStop = String(autoStop);
-    if (playlistIds.length > 0) {
-      obj.playlistIds = JSON.stringify(playlistIds);
+    if (playlistIds.length > 0) obj.playlistIds = JSON.stringify(playlistIds);
+    // Only send streamKeyId if user explicitly changed it
+    if (selectedKeyId && selectedKeyId !== stream.boundStreamId) {
+      obj.streamKeyId = selectedKeyId;
     }
     onSubmit(obj);
   };
@@ -73,9 +186,7 @@ export default function EditStreamModal({
         <input type="hidden" name="id" value={stream.id} />
 
         <div>
-          <label className={labelClass} htmlFor="edit-title">
-            Title
-          </label>
+          <label className={labelClass} htmlFor="edit-title">Title</label>
           <input
             id="edit-title"
             type="text"
@@ -86,9 +197,7 @@ export default function EditStreamModal({
         </div>
 
         <div>
-          <label className={labelClass} htmlFor="edit-desc">
-            Description
-          </label>
+          <label className={labelClass} htmlFor="edit-desc">Description</label>
           <textarea
             id="edit-desc"
             name="description"
@@ -98,11 +207,24 @@ export default function EditStreamModal({
           />
         </div>
 
-        {/* Scheduled start time — editable for upcoming streams, read-only otherwise */}
+        {/* Stream key — primary info at a glance */}
+        <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-3 bg-gray-50 dark:bg-gray-900/50">
+          <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">Stream Key</p>
+          {stream.streamKeyName ? (
+            <p className="text-sm font-medium text-gray-800 dark:text-gray-100 font-mono">
+              {stream.streamKeyName}
+              {stream.boundStreamId && (
+                <span className="ml-2 text-xs font-normal text-gray-400 dark:text-gray-500">{stream.boundStreamId}</span>
+              )}
+            </p>
+          ) : (
+            <p className="text-xs text-gray-400 dark:text-gray-500 italic">No key bound</p>
+          )}
+        </div>
+
+        {/* Scheduled start time */}
         <div>
-          <label className={labelClass} htmlFor="edit-startTime">
-            Scheduled For
-          </label>
+          <label className={labelClass} htmlFor="edit-startTime">Scheduled For</label>
           {!stream.isLive && !stream.isComplete ? (
             <input
               id="edit-startTime"
@@ -112,51 +234,29 @@ export default function EditStreamModal({
               className={`${inputClass} datetime-input`}
             />
           ) : (
-            <input
-              type="text"
-              defaultValue={toLocalDatetime(stream.startTime)}
-              disabled
-              className={disabledInputClass}
-            />
+            <input type="text" defaultValue={toLocalDatetime(stream.startTime)} disabled className={disabledInputClass} />
           )}
         </div>
 
-        {/* Actual times shown for completed streams */}
+        {/* Actual times for completed streams */}
         {stream.isComplete && (
           <>
             <div>
               <label className={labelClass}>Actual Start</label>
-              <input
-                type="text"
-                defaultValue={toLocalDatetime(stream.actualStartTime)}
-                disabled
-                className={disabledInputClass}
-              />
+              <input type="text" defaultValue={toLocalDatetime(stream.actualStartTime)} disabled className={disabledInputClass} />
             </div>
             <div>
               <label className={labelClass}>Actual End</label>
-              <input
-                type="text"
-                defaultValue={toLocalDatetime(stream.actualEndTime)}
-                disabled
-                className={disabledInputClass}
-              />
+              <input type="text" defaultValue={toLocalDatetime(stream.actualEndTime)} disabled className={disabledInputClass} />
             </div>
           </>
         )}
 
-        {/* Privacy status — editable for upcoming and live streams */}
+        {/* Privacy */}
         {!stream.isComplete && (
           <div>
-            <label className={labelClass} htmlFor="edit-privacy">
-              Privacy
-            </label>
-            <select
-              id="edit-privacy"
-              name="privacyStatus"
-              defaultValue={stream.privacyStatus}
-              className={inputClass}
-            >
+            <label className={labelClass} htmlFor="edit-privacy">Privacy</label>
+            <select id="edit-privacy" name="privacyStatus" defaultValue={stream.privacyStatus} className={inputClass}>
               <option value="public">Public</option>
               <option value="unlisted">Unlisted</option>
               <option value="private">Private</option>
@@ -164,27 +264,17 @@ export default function EditStreamModal({
           </div>
         )}
 
-        {/* Auto-start / auto-stop checkboxes */}
+        {/* Auto-start / auto-stop */}
         {!stream.isComplete && (
           <div className="flex gap-6">
             {!stream.isLive && (
               <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 cursor-pointer select-none">
-                <input
-                  type="checkbox"
-                  checked={autoStart}
-                  onChange={(e) => setAutoStart(e.target.checked)}
-                  className="accent-blue-600 w-4 h-4"
-                />
+                <input type="checkbox" checked={autoStart} onChange={(e) => setAutoStart(e.target.checked)} className="accent-blue-600 w-4 h-4" />
                 auto-start
               </label>
             )}
             <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 cursor-pointer select-none">
-              <input
-                type="checkbox"
-                checked={autoStop}
-                onChange={(e) => setAutoStop(e.target.checked)}
-                className="accent-blue-600 w-4 h-4"
-              />
+              <input type="checkbox" checked={autoStop} onChange={(e) => setAutoStop(e.target.checked)} className="accent-blue-600 w-4 h-4" />
               auto-stop
             </label>
           </div>
@@ -192,11 +282,89 @@ export default function EditStreamModal({
 
         <div>
           <label className={labelClass}>Add to Playlists</label>
-          <PlaylistMultiSelect
-            selectedIds={playlistIds}
-            onChange={setPlaylistIds}
-            videoId={stream.id}
-          />
+          <PlaylistMultiSelect selectedIds={playlistIds} onChange={setPlaylistIds} videoId={stream.id} />
+        </div>
+
+        {/* Advanced settings accordion */}
+        <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+          <button
+            type="button"
+            onClick={() => setShowAdvanced((v) => !v)}
+            className="w-full flex items-center justify-between px-4 py-2.5 text-sm font-medium text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+          >
+            <span>Advanced settings</span>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className={`w-4 h-4 transition-transform ${showAdvanced ? 'rotate-180' : ''}`}
+            >
+              <path fillRule="evenodd" d="M5.22 8.22a.75.75 0 011.06 0L10 11.94l3.72-3.72a.75.75 0 111.06 1.06l-4.25 4.25a.75.75 0 01-1.06 0L5.22 9.28a.75.75 0 010-1.06z" clipRule="evenodd" />
+            </svg>
+          </button>
+
+          {showAdvanced && (
+            <div className="px-4 pb-4 pt-2 border-t border-gray-200 dark:border-gray-700 space-y-4">
+              {/* Stream key selector */}
+              <div>
+                <label className={labelClass} htmlFor="edit-stream-key-select">Bound Stream Key</label>
+                {keysLoading && (
+                  <p className="text-xs text-gray-400 dark:text-gray-500">Loading keys…</p>
+                )}
+                {keysError && (
+                  <p className="text-xs text-red-500">{keysError}</p>
+                )}
+                {!keysLoading && !keysError && (
+                  <select
+                    id="edit-stream-key-select"
+                    value={selectedKeyId}
+                    onChange={(e) => setSelectedKeyId(e.target.value)}
+                    className={inputClass}
+                  >
+                    <option value="">— select a stream key —</option>
+                    {availableKeys.map((k) => (
+                      <option key={k.id} value={k.id}>
+                        {k.name}{k.resolution ? ` (${k.resolution}${k.frameRate ? ` · ${k.frameRate}` : ''})` : ''}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </div>
+
+              {/* Ingestion credentials for the selected key */}
+              {keyInfoLoading && (
+                <p className="text-xs text-gray-400 dark:text-gray-500">Loading credentials…</p>
+              )}
+              {keyInfo && !keyInfoLoading && (
+                <div className="space-y-3">
+                  <div className="space-y-1">
+                    <span className="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">Stream URL (Primary)</span>
+                    <div className="flex items-center gap-2">
+                      <code className="flex-1 text-xs bg-gray-100 dark:bg-gray-900 rounded px-2 py-1.5 font-mono break-all select-all">
+                        {keyInfo.ingestionAddress}
+                      </code>
+                      <CopyButton value={keyInfo.ingestionAddress} label="Stream URL" />
+                    </div>
+                  </div>
+                  {keyInfo.backupIngestionAddress && (
+                    <div className="space-y-1">
+                      <span className="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">Stream URL (Backup)</span>
+                      <div className="flex items-center gap-2">
+                        <code className="flex-1 text-xs bg-gray-100 dark:bg-gray-900 rounded px-2 py-1.5 font-mono break-all select-all">
+                          {keyInfo.backupIngestionAddress}
+                        </code>
+                        <CopyButton value={keyInfo.backupIngestionAddress} label="Backup Stream URL" />
+                      </div>
+                    </div>
+                  )}
+                  <SecretRow label="Stream Key" value={keyInfo.streamKey} />
+                  <p className="text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-900 rounded px-3 py-2">
+                    Keep your stream key private. Anyone with it can stream to your channel.
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </form>
     </Modal>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,7 +20,29 @@ export interface FormattedStream {
   privacyStatus: string;
   videoLink: string;
   controlRoomLink: string;
+  boundStreamId?: string;
+  streamKeyName?: string;
 }
+
+export interface AvailableStreamKey {
+  id: string;
+  name: string;
+  resolution?: string;
+  frameRate?: string;
+  ingestionType?: string;
+}
+
+export interface StreamKeyInfo {
+  streamId: string;
+  streamTitle: string;
+  streamKey: string;
+  ingestionAddress: string;
+  backupIngestionAddress?: string;
+  resolution?: string;
+  frameRate?: string;
+  ingestionType?: string;
+}
+
 
 export interface StreamsData {
   active: FormattedStream[];

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -14,7 +14,7 @@ export async function parallelAsync<T extends Record<string, Promise<unknown>>>(
   );
 }
 
-export function formatStreams(livestreams: unknown): FormattedStream[] {
+export function formatStreams(livestreams: unknown, streamKeyNames?: Map<string, string>): FormattedStream[] {
   const data = livestreams as { data?: { items?: unknown[] } };
   if (!data?.data?.items) return [];
   return (data.data.items as Record<string, unknown>[]).map((o) => {
@@ -22,6 +22,7 @@ export function formatStreams(livestreams: unknown): FormattedStream[] {
     const contentDetails = o.contentDetails as Record<string, unknown>;
     const status = o.status as Record<string, unknown>;
     const thumbnails = snippet.thumbnails as Record<string, unknown> | undefined;
+    const boundStreamId = (contentDetails.boundStreamId as string | undefined) ?? undefined;
     return {
       id: o.id as string,
       title: snippet.title as string,
@@ -38,6 +39,8 @@ export function formatStreams(livestreams: unknown): FormattedStream[] {
       privacyStatus: status.privacyStatus as string,
       videoLink: `https://www.youtube.com/watch?v=${o.id}`,
       controlRoomLink: `https://studio.youtube.com/video/${o.id}/livestreaming`,
+      boundStreamId: (contentDetails.boundStreamId as string | undefined) ?? undefined,
+      streamKeyName: boundStreamId ? (streamKeyNames?.get(boundStreamId) ?? undefined) : undefined,
     };
   });
 }

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -1,4 +1,5 @@
 import { google, youtube_v3 } from 'googleapis';
+import type { StreamKeyInfo } from './types';
 import type { StreamStatus } from './constants';
 import { streamStatus as STATUS } from './constants';
 
@@ -93,5 +94,77 @@ export async function createStream(accessToken: string, data: CreateStreamData) 
         },
       },
     },
+  });
+}
+
+export async function getLiveStreamByBroadcastId(
+  accessToken: string,
+  broadcastId: string,
+): Promise<StreamKeyInfo | null> {
+  const youtube = getYoutubeClient(accessToken);
+
+  const broadcastRes = await youtube.liveBroadcasts.list({
+    part: ['contentDetails'],
+    id: [broadcastId],
+  });
+  const boundStreamId = broadcastRes.data.items?.[0]?.contentDetails?.boundStreamId;
+  if (!boundStreamId) return null;
+
+  const streamRes = await youtube.liveStreams.list({
+    part: ['snippet', 'cdn'],
+    id: [boundStreamId],
+  });
+  const liveStream = streamRes.data.items?.[0];
+  if (!liveStream) return null;
+
+  const cdn = liveStream.cdn;
+  const ingestionInfo = cdn?.ingestionInfo;
+
+  return {
+    streamId: boundStreamId,
+    streamTitle: liveStream.snippet?.title ?? '',
+    streamKey: ingestionInfo?.streamName ?? '',
+    ingestionAddress: ingestionInfo?.ingestionAddress ?? '',
+    backupIngestionAddress: ingestionInfo?.backupIngestionAddress ?? undefined,
+    resolution: cdn?.resolution ?? undefined,
+    frameRate: cdn?.frameRate ?? undefined,
+    ingestionType: cdn?.ingestionType ?? undefined,
+  };
+}
+
+/** Fetch multiple liveStreams by their IDs in a single API call. */
+export async function getLiveStreamsByIds(accessToken: string, streamIds: string[]) {
+  if (streamIds.length === 0) return [];
+  const youtube = getYoutubeClient(accessToken);
+  const res = await youtube.liveStreams.list({
+    part: ['snippet', 'cdn'],
+    id: streamIds,
+    maxResults: 50,
+  });
+  return res.data.items ?? [];
+}
+
+/** List all stream keys belonging to the authenticated user. */
+export async function getMyLiveStreams(accessToken: string) {
+  const youtube = getYoutubeClient(accessToken);
+  const res = await youtube.liveStreams.list({
+    part: ['snippet', 'cdn'],
+    mine: true,
+    maxResults: 50,
+  });
+  return res.data.items ?? [];
+}
+
+/** Bind a broadcast to a specific stream key. */
+export async function bindBroadcastToStream(
+  accessToken: string,
+  broadcastId: string,
+  streamId: string,
+) {
+  const youtube = getYoutubeClient(accessToken);
+  return youtube.liveBroadcasts.bind({
+    id: broadcastId,
+    streamId,
+    part: ['id', 'contentDetails'],
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-livestream-console",
-  "version": "3.0.0",
+  "version": "3.5.0",
   "private": true,
   "engines": {
     "node": ">=24.0.0"


### PR DESCRIPTION
## Summary

Two related feature areas shipped together: full stream key visibility/management across the app, and a useful Dashboard with an active stream card, history metrics, and a persistent Create Stream entry point.

---

## Stream Key Management

Previously there was no visibility into which encoder key was bound to a broadcast, and no way to change it in-app.

### New API routes

- **`GET /api/streams/keys`** — lists all YouTube liveStream encoder keys for the authenticated user (`getMyLiveStreams`)
- **`GET /api/streams/[id]/streamkey`** — returns full credentials (stream key, ingestion address, backup address) for the key bound to a specific broadcast

### `lib/youtube.ts`

Four new exports: `getLiveStreamByBroadcastId`, `getLiveStreamsByIds`, `getMyLiveStreams`, `bindBroadcastToStream`

### `lib/types.ts`

- `FormattedStream` gains `boundStreamId` and `streamKeyName`
- New interfaces: `AvailableStreamKey`, `StreamKeyInfo`

### `lib/utils.ts` / `app/streams/page.tsx`

- `formatStreams` accepts an optional `Map<streamId, keyName>` for enriched display
- Streams page bulk-fetches key names server-side and passes them down

### `app/api/streams/edit/[id]/route.ts`

Accepts `streamKeyId` in the request body; calls `bindBroadcastToStream` when the key changes.

### UI updates

- **`EditStreamModal`** — key name always shown at the top; expandable accordion with a key selector dropdown, full credentials display, and copy/show-password buttons. Only sends `streamKeyId` on submit if the user actually changed it.
- **`StreamCard`, `StreamTableRow`, `StreamFeatured`** — bound key name shown inline with a key icon (no separate modal needed)
- **`StreamsClient`** — "Stream Key" column added to upcoming and completed tables; `StreamKeyModal` removed

---

## Dashboard Overhaul

The dashboard was previously near-empty (just two buttons). It now fetches real data server-side and renders a `DashboardClient` component.

### `app/dashboard/page.tsx`

Fetches active, completed, and upcoming broadcasts in parallel (same pattern as the streams page, including bulk key name resolution). Degrades gracefully on API errors.

### `components/DashboardClient.tsx` (new)

- **Primary actions** (Upcoming Streams + Create Stream) remain prominent at the top
- **Active stream card** — only shown when something is live. Displays a pulsing `● LIVE` badge, stream title, bound key name, live-since time, and Stop / Edit / Control Room buttons wired to real modals
- **Stream history metrics** — segmented control to switch between Today / 7 Days / 30 Days; shows completed streams in period, upcoming scheduled count, and a live/total-completed stat tile

---

## Create Stream improvements

- **`CreateStreamModal`** — stream key dropdown added (fetches `/api/streams/keys` on mount, optional). Includes loading skeleton while keys are fetching.
- **`app/api/streams/create/route.ts`** — accepts `streamKeyId`; calls `bindBroadcastToStream` after the broadcast is created (best-effort, same as playlist adds)
- **`StreamsClient`** — "+ Create Stream" button added to the Upcoming Streams heading bar, alongside the existing view toggle

---

## Testing

- `npx tsc --noEmit` — exits 0, no type errors
- All existing stream CRUD flows (create, edit, stop, delete) unaffected
- Stream key binding is best-effort (failures don't block the create/edit response)

---

## 🏷️ Release label

| Label | Effect |
| --- | --- |
| `release:patch` | Bug fixes, small tweaks — e.g. `v3.5.0 → v3.5.1` |
| `release:minor` | New backwards-compatible features — e.g. `v3.5.0 → v3.6.0` |
| `release:major` | Breaking changes — e.g. `v3.5.0 → v4.0.0` |

**Suggested label: `release:minor`** — multiple new backwards-compatible features across stream key management, dashboard, and create flow.