### PR TITLE
fix: align Stream Key column header with data cell position

### DIFF
--- a/components/StreamsClient.tsx
+++ b/components/StreamsClient.tsx
@@ -610,6 +610,22 @@ export default function StreamsClient({ streams, error }: StreamsClientProps) {
                                                                 { key: 'title', label: 'Title' },
                                                                 { key: 'startTime', label: 'Scheduled' },
                                                                 { key: 'privacyStatus', label: 'Privacy' },
+                                                            ] as { key: SortKey; label: string }[]
+                                                        ).map(({ key, label }) => (
+                                                            <th
+                                                                key={key}
+                                                                onClick={() => handleUpcomingSort(key)}
+                                                                className="py-2.5 px-4 text-left cursor-pointer select-none hover:text-gray-800 dark:hover:text-gray-200 transition-colors whitespace-nowrap"
+                                                            >
+                                                                {label}
+                                                                {upcomingSortKey === key && (
+                                                                    <span className="ml-1 text-blue-500">{upcomingSortDir === 'asc' ? '↑' : '↓'}</span>
+                                                                )}
+                                                            </th>
+                                                        ))}
+                                                        <th className="py-2.5 px-4 text-left">Stream Key</th>
+                                                        {(
+                                                            [
                                                                 { key: 'enableAutoStart', label: 'Auto-start' },
                                                                 { key: 'enableAutoStop', label: 'Auto-stop' },
                                                             ] as { key: SortKey; label: string }[]
@@ -617,15 +633,15 @@ export default function StreamsClient({ streams, error }: StreamsClientProps) {
                                                             <th
                                                                 key={key}
                                                                 onClick={() => handleUpcomingSort(key)}
-                                                                className={`py-2.5 px-4 cursor-pointer select-none hover:text-gray-800 dark:hover:text-gray-200 transition-colors whitespace-nowrap ${key === 'enableAutoStart' || key === 'enableAutoStop' ? 'text-center' : 'text-left'
-                                                                    }`}
+                                                                className="py-2.5 px-4 text-center cursor-pointer select-none hover:text-gray-800 dark:hover:text-gray-200 transition-colors whitespace-nowrap"
                                                             >
                                                                 {label}
                                                                 {upcomingSortKey === key && (
                                                                     <span className="ml-1 text-blue-500">{upcomingSortDir === 'asc' ? '↑' : '↓'}</span>
                                                                 )}
                                                             </th>
-                                                        ))}                                                        <th className="py-2.5 px-4 text-left">Stream Key</th>                                                        <th className="py-2.5 px-4 text-right">Actions</th>
+                                                        ))}
+                                                        <th className="py-2.5 px-4 text-right">Actions</th>
                                                     </tr>
                                                 </thead>
                                                 <tbody className="divide-y divide-gray-100 dark:divide-gray-700 bg-white dark:bg-gray-900">
@@ -727,15 +743,12 @@ export default function StreamsClient({ streams, error }: StreamsClientProps) {
                                                                 { key: 'title', label: 'Title' },
                                                                 { key: 'startTime', label: 'Scheduled' },
                                                                 { key: 'privacyStatus', label: 'Privacy' },
-                                                                { key: 'enableAutoStart', label: 'Auto-start' },
-                                                                { key: 'enableAutoStop', label: 'Auto-stop' },
                                                             ] as { key: SortKey; label: string }[]
                                                         ).map(({ key, label }) => (
                                                             <th
                                                                 key={key}
                                                                 onClick={() => handleCompletedSort(key)}
-                                                                className={`py-2.5 px-4 cursor-pointer select-none hover:text-gray-800 dark:hover:text-gray-200 transition-colors whitespace-nowrap ${key === 'enableAutoStart' || key === 'enableAutoStop' ? 'text-center' : 'text-left'
-                                                                    }`}
+                                                                className="py-2.5 px-4 text-left cursor-pointer select-none hover:text-gray-800 dark:hover:text-gray-200 transition-colors whitespace-nowrap"
                                                             >
                                                                 {label}
                                                                 {completedSortKey === key && (
@@ -744,6 +757,23 @@ export default function StreamsClient({ streams, error }: StreamsClientProps) {
                                                             </th>
                                                         ))}
                                                         <th className="py-2.5 px-4 text-left">Stream Key</th>
+                                                        {(
+                                                            [
+                                                                { key: 'enableAutoStart', label: 'Auto-start' },
+                                                                { key: 'enableAutoStop', label: 'Auto-stop' },
+                                                            ] as { key: SortKey; label: string }[]
+                                                        ).map(({ key, label }) => (
+                                                            <th
+                                                                key={key}
+                                                                onClick={() => handleCompletedSort(key)}
+                                                                className="py-2.5 px-4 text-center cursor-pointer select-none hover:text-gray-800 dark:hover:text-gray-200 transition-colors whitespace-nowrap"
+                                                            >
+                                                                {label}
+                                                                {completedSortKey === key && (
+                                                                    <span className="ml-1 text-blue-500">{completedSortDir === 'asc' ? '↑' : '↓'}</span>
+                                                                )}
+                                                            </th>
+                                                        ))}
                                                         <th className="py-2.5 px-4 text-right">Actions</th>
                                                     </tr>
                                                 </thead>


### PR DESCRIPTION
## Bug

The "Stream Key" column header was misaligned with the actual data in both the upcoming and completed stream tables.

`StreamTableRow` renders cells in order: **Title → Scheduled → Privacy → Stream Key → Auto-start → Auto-stop → Actions**

But `StreamsClient` rendered headers in order: **Title → Scheduled → Privacy → Auto-start → Auto-stop → Stream Key → Actions** — with Stream Key bolted onto the end of the sortable header array instead of being inserted at the correct position.

## Fix

Split the sortable header array at `privacyStatus` and insert the static Stream Key `<th>` between Privacy and Auto-start in both the upcoming and completed table headers. Applied to both tables.

## Testing

- `npx tsc --noEmit` — exits 0
- Column headers now line up: Privacy → Stream Key → Auto-start → Auto-stop → Actions

---

## 🏷️ Release label

| Label | Effect |
| --- | --- |
| `release:patch` | Bug fixes, small tweaks — e.g. `v3.5.0 → v3.5.1` |
| `release:minor` | New backwards-compatible features — e.g. `v3.5.0 → v3.6.0` |
| `release:major` | Breaking changes — e.g. `v3.5.0 → v4.0.0` |

**Applied label: `release:patch`** — visual bug fix only.